### PR TITLE
Fix crash when opening a push notification

### DIFF
--- a/plugin_manifest.json
+++ b/plugin_manifest.json
@@ -1,43 +1,104 @@
 {
   "api": {
-    "require_startup_execution": false,
+    "require_startup_execution": true,
     "class_name": "com.applicaster.reshetplayer.StartHere"
   },
-  "dependency_repository_url": [
-    
-  ],
+  "dependency_repository_url": ["https://github.com/applicaster/ReshetPlayer-Android"],
   "platform": "android",
-  "author_name": "Shay markovich",
-  "author_email": "s.markovich@applicaster.com",
-  "manifest_version": "0.1.0",
+  "author_name": "Pablo Rueda",
+  "author_email": "p.rueda@applicaster.com",
+  "manifest_version": "0.8.0",
   "name": "Reshet Player",
   "description": "A plugin player for reshet that can display video ads from ArtiMedia and uses kantar",
   "type": "player",
   "identifier": "reshetplayer-android",
   "dependency_name": "com.applicaster:ReshetPlayer",
-  "dependency_version": "0.1.+",
-  "whitelisted_account_ids": [
-    "5891b9f978f9f300171455e5"
-  ],
+  "dependency_version": "0.8.+",
+  "whitelisted_account_ids": ["5891b9f978f9f300171455e5", "5c6abadabaa924000cb6000c"],
   "min_zapp_sdk": "11.2.0-rc",
   "ui_builder_support": false,
   "deprecated_since_zapp_sdk": "",
   "unsupported_since_zapp_sdk": "",
   "react_native": false,
-  "custom_configuration_fields": [
-    {
-      "type": "text",
-      "key": "site_key",
-      "tooltip_text": "ArtiMedia SiteKey"
-    },
-    {
-      "type": "checkbox",
-      "key": "show_ads_on_payed",
-      "default": 0,
-      "tooltip_text": "Display ads on payed items"
-    }
-  ],
-  "targets": [
-    "mobile"
-  ]
+  "custom_configuration_fields": [{
+    "type": "text",
+    "key": "artimedia_site_key",
+    "label": "Artimedia site key",
+    "placeholder": "Choose site key",
+    "tooltip_text": "ArtiMedia SiteKey"
+  }, {
+    "type": "checkbox",
+    "key": "show_ads_on_payed",
+    "label": "Show ads on payed",
+    "default": 0,
+    "tooltip_text": "Display ads on payed items"
+  }, {
+    "type": "text",
+    "key": "kantar_site_key",
+    "label": "Kantar site key",
+    "placeholder": "Choose site key",
+    "tooltip_text": "Kantar SiteKey"
+  }, {
+    "type": "text",
+    "key": "live_stream_url",
+    "label": "live stream url",
+    "placeholder": "https://...\u0026DVR",
+    "tooltip_text": "live stream url should have \u0026DVR attribute"
+  }, {
+    "type": "text",
+    "key": "c1_cut_time",
+    "label": "c1 cut time",
+    "placeholder": "HH:MM",
+    "tooltip_text": "c1 cut time in HH:MM format UTC i.e 00:00 or 23:00"
+  }, {
+    "type": "text",
+    "key": "c1_window_length_time",
+    "label": "c1 window length time",
+    "placeholder": "i.e 129600000 = 36 hours",
+    "tooltip_text": "c1_window_length_time in UTC, milesec sence 1970"
+  }, {
+    "type": "text",
+    "key": "server_time_url",
+    "label": "time server url",
+    "placeholder": "https://...",
+    "tooltip_text": "server time url"
+  }, {
+    "type": "text",
+    "key": "kantar_player_version_name",
+    "label": "kantart player name",
+    "placeholder": "",
+    "tooltip_text": "player version name that will be send to kantar"
+  }, {
+    "type": "text",
+    "key": "kantar_player_version",
+    "label": "kantar player version",
+    "placeholder": "",
+    "tooltip_text": "player version name that will be send to kantar"
+  }, {
+    "type": "text",
+    "key": "kantar_attribute_stream_value",
+    "placeholder": "i.e live/channelname",
+    "tooltip_text": "attribute stream value that will be send to kantar"
+  }, {
+    "type": "text",
+    "key": "ovidius_url",
+    "placeholder": "https://13tv-api.oplayer.io/",
+    "tooltip_text": "ovidius base url for secure video"
+  }, {
+    "type": "text",
+    "key": "ovidius_user_ID",
+    "placeholder": "45E4A9FB-FCE8-88BF-93CC-3650C39DDF28",
+    "tooltip_text": "ovidius user id for ovidius api service"
+  }, {
+    "type": "text",
+    "key": "ovidius_cdn_name",
+    "placeholder": "casttime",
+    "tooltip_text": "ovidius can name"
+  }, {
+    "type": "text",
+    "key": "ovidius_ch",
+    "placeholder": "1",
+    "tooltip_text": "ovidius channel"
+  }],
+  "targets": ["mobile"]
 }

--- a/src/main/java/com/applicaster/reshetplayer/StartHere.java
+++ b/src/main/java/com/applicaster/reshetplayer/StartHere.java
@@ -192,7 +192,6 @@ public class StartHere extends DefaultPlayerWrapper implements ApplicationLoader
 
     @Override
     public void executeOnApplicationReady(Context context, HookListener listener) {
-        initPluginParams();
 
         String serverUrl = PluginParams.INSTANCE.getServerTimeUrl();
         registerActivityCallback();
@@ -253,6 +252,7 @@ public class StartHere extends DefaultPlayerWrapper implements ApplicationLoader
 
     @Override
     public void executeOnStartup(Context context, HookListener listener) {
+        initPluginParams();
         listener.onHookFinished();
     }
 


### PR DESCRIPTION
There was a crash when opening a push notification with an url scheme that launched the player. This was because the player was launched before calling the executeOnApplicationReady method.

The initialization of the parameters should be done during executeOnStartup and not in executeOnApplicationReady.

I updated the manifest that was not updated since the first version.